### PR TITLE
Update deprecated values in Cloud-Config

### DIFF
--- a/guacamole-rdp-vnc-gateway-existing-vnet/scripts/cloud-config.yaml
+++ b/guacamole-rdp-vnc-gateway-existing-vnet/scripts/cloud-config.yaml
@@ -1,7 +1,7 @@
 #cloud-config
 coreos:
   update:
-    reboot-strategy: best-effort
+    reboot-strategy: etcd-lock
   units:
     - name: docker.service
       command: start


### PR DESCRIPTION
The "reboot-strategy: best-effort" in Cloud-Config has been deprecated and removed from Locksmith begining Sep 14, 2017 ( reference - https://coreos.com/blog/locksmith-update-strategy-revision ) and is not available in current CoreOS Version 1855.5.0. This is causing Failed Units in Docker upon startup. Updating reboot-strategy: etcd-lock will fix the issue and make the work template to work as expected.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

